### PR TITLE
Changed to use futimes instead of utimes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(options) {
 		if (file.isNull()) { return cb(null, file); }
 
 		// opens file
-       fs.open(file.path, 'r', function(err, fd) {
+       fs.open(file.path, 'a', function(err, fd) {
            if (err) {
                cb(err, file);
                return;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,23 @@ var map = require('map-stream');
 module.exports = function(options) {
 	return map(function(file, cb) {
 		if (file.isNull()) { return cb(null, file); }
-		
-		// Update file modification and access time
-        return fs.utimes(file.path, file.stat.atime, file.stat.mtime, cb);
+
+		// opens file
+       fs.open(file.path, 'r', function(err, fd) {
+           if (err) {
+               cb(err, file);
+               return;
+           }
+
+           // Update file modification and access time
+           fs.futimes(fd, file.stat.atime, file.stat.mtime, function(err) {
+                if (err) {
+                    cb(err, file);
+                    return;
+                }
+
+                fs.close(fd, cb);
+           });
+       });
 	});
 }

--- a/test.js
+++ b/test.js
@@ -16,13 +16,13 @@ var firstTestFile = '/a',
 
 beforeEach(function() {
 	clearUp();
-	fs.mkdirsSync(subdir, 0o777);
+	fs.mkdirsSync(subdir, parseInt('777', 8));
 	fs.writeFileSync(srcdir + firstTestFile, 'Test Data', {
-		mode: 0o777
+		mode: parseInt('777', 8)
 	});
 	fs.utimesSync(srcdir + firstTestFile, atime, mtime);
 	fs.writeFileSync(srcdir + secondTestFile, 'Test Data', {
-		mode: 0o777
+		mode: parseInt('777', 8)
 	});
 	fs.utimesSync(srcdir + secondTestFile, atime, mtime);
 })

--- a/test.js
+++ b/test.js
@@ -10,21 +10,17 @@ var atime = new Date(2000, 1, 2, 3, 4, 5),
 	mtime = new Date(2010, 10, 12, 13, 14, 15),
 	srcdir = './test-src',
 	dest = './test-dest';
-var	subdir = srcdir + '/subdir'; 
+var	subdir = srcdir + '/subdir';
 var firstTestFile = '/a',
 	secondTestFile = '/subdir/b';
 
-before(function() {
+beforeEach(function() {
 	clearUp();
 	fs.mkdirsSync(subdir);
 	fs.writeFileSync(srcdir + firstTestFile, 'Test Data');
 	fs.utimesSync(srcdir + firstTestFile, atime, mtime);
 	fs.writeFileSync(srcdir + secondTestFile, 'Test Data');
 	fs.utimesSync(srcdir + secondTestFile, atime, mtime);
-});
-
-beforeEach(function() {
-	clearOutput();
 })
 
 after(function() {
@@ -32,47 +28,47 @@ after(function() {
 })
 
 it('should preserve file mtime', function(cb) {
-	
+
 	gulp.src(srcdir + '/**/*')
 		.pipe(gulp.dest(dest))
 		.pipe(preservetime())
 		.pipe(es.wait(function(err, data) {
-			
+
 			// Read file modification times in dest
 			var firstFileStats = fs.statSync(dest + firstTestFile),
 				secondFileStats = fs.statSync(dest + secondTestFile);
-			
+
 			firstFileStats.mtime.getTime().should.equal(mtime.getTime());
 			secondFileStats.mtime.getTime().should.equal(mtime.getTime());
-			
+
 			cb();
 		}));
 });
 
 it('should preserve file atime', function(cb) {
-	
+
 	gulp.src(srcdir + '/**/*')
 		.pipe(gulp.dest(dest))
 		.pipe(preservetime())
 		.pipe(es.wait(function(err, data) {
-			
+
 			// Read file modification times in dest
 			var firstFileStats = fs.statSync(dest + firstTestFile),
 				secondFileStats = fs.statSync(dest + secondTestFile);
-			
+
 			firstFileStats.atime.getTime().should.equal(atime.getTime());
 			secondFileStats.atime.getTime().should.equal(atime.getTime());
-			
+
 			cb();
 		}));
 });
 
 
 function clearUp() {
-	if (fs.existsSync(srcdir)) { 
+	if (fs.existsSync(srcdir)) {
 		fs.removeSync(srcdir);
 	}
-	clearOutput(); 
+	clearOutput();
 }
 
 function clearOutput() {


### PR DESCRIPTION
As stated [here](https://github.com/nodejs/node-v0.x-archive/issues/7000) `utimes` has 1 second resolution, whereas `futimes` has 1 microsecond resolution.
Since `stat` also has a 1 microsecond resolution, this caused conditional builds (with [gulp-newer](https://www.npmjs.com/package/gulp-newer) for instance) to always rebuild files on platforms with 1 microsecond timestamps for files (Linux with ext2/3).
