### PR TITLE
Fixed pipe interruption

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,25 +4,29 @@ var fs = require('graceful-fs');
 var map = require('map-stream');
 
 module.exports = function(options) {
-	return map(function(file, cb) {
-		if (file.isNull()) { return cb(null, file); }
+  return map(function(file, cb) {
+    if (file.isNull()) { return cb(null, file); }
 
-		// opens file
-       fs.open(file.path, 'a', function(err, fd) {
-           if (err) {
-               cb(err, file);
-               return;
-           }
+    // opens file
+    fs.open(file.path, 'a', function(err, fd) {
+      if (err) {
+          cb(err, file);
+          return;
+      }
 
-           // Update file modification and access time
-           fs.futimes(fd, file.stat.atime, file.stat.mtime, function(err) {
-                if (err) {
-                    cb(err, file);
-                    return;
-                }
+      if(file.stat.atime && file.stat.mtime){
+        // Update file modification and access time
+        fs.futimes(fd, file.stat.atime, file.stat.mtime, function(err) {
+          if (err) {
+              cb(err, file);
+              return;
+          }
 
-                fs.close(fd, cb);
-           });
-       });
-	});
+          fs.close(fd, cb);
+        });
+      }
+    });
+
+    cb(null, file);
+  });
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(options) {
               return;
           }
 
-          fs.close(fd, cb);
+          fs.close(fd);
         });
       }
     });

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(options) {
           return;
       }
 
-      if(file.stat.atime && file.stat.mtime){
+      if (file.stat.atime && file.stat.mtime) {
         // Update file modification and access time
         fs.futimes(fd, file.stat.atime, file.stat.mtime, function(err) {
           if (err) {
@@ -22,11 +22,14 @@ module.exports = function(options) {
               return;
           }
 
-          fs.close(fd);
+          fs.close(fd, function () {
+            cb(null, file);
+          });
         });
+      } else {
+        // File may be not null, but has change name (map, etc)
+        cb(null, file);
       }
     });
-
-    cb(null, file);
   });
 }


### PR DESCRIPTION
Call a stream-map callback not only on file closing to enable preservetime respond file-buffer to pipe stream.

```
gulp.task('css', function(){
    return gulp
        .src('/css/in/')
        .pipe(prefixer())
        .pipe(gulp.dest('/css/out/'))
        .pipe(preservetime()) /* now doesn't stops here, keeps processing */
        .pipe(sourcemaps.init())
        .pipe(minify_css())
        .pipe(sourcemaps.write('.'))
        .pipe(gulp.dest('/css/out/min/'))
        .pipe(preservetime())
        ;
});
```
